### PR TITLE
Made Aphid open class

### DIFF
--- a/Sources/Aphid.swift
+++ b/Sources/Aphid.swift
@@ -21,7 +21,7 @@ import Dispatch
 
 public typealias Byte = UInt8
 
-public class Aphid {
+open class Aphid {
 
     public var delegate: MQTTDelegate?
 


### PR DESCRIPTION
In order for the Aphid class to allow inheritance on it now, we need to make in `open` instead of `public`.

https://github.com/apple/swift-evolution/blob/master/proposals/0117-non-public-subclassable-by-default.md
