### PR TITLE
Fix for empty strings (e.g. in password)

### DIFF
--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -35,19 +35,21 @@ extension String {
     var data: Data {
         var array = Data()
         
-        let utf = self.data(using: String.Encoding.utf8)!
-        array.append(UInt16(utf.count).data)
-        array.append(utf)
-        
+        if let utf = self.data(using: String.Encoding.utf8) {
+            array.append(UInt16(utf.count).data)
+            array.append(utf)
+        } else {
+            array.append(UInt16(0).data)
+        }
         return array
     }
     
     var sData: Data {
         var array = Data()
         
-        let utf = self.data(using: String.Encoding.utf8)!
-        array.append(utf)
-        
+        if let utf = self.data(using: String.Encoding.utf8) {
+            array.append(utf)
+        }
         return array
     }
     


### PR DESCRIPTION
Some brokers such as AT&T A2X expect an empty password so I instinctively tried to init Aphid with an empty string literal like this:
`let client = Aphid(clientId: clientId, username: "fa393bb9fa3b8b04aff1ff78433b8xxx", password: "")`
and found that crashes with _fatal error: unexpectedly found nil while unwrapping an Optional value_

Setting password = nil (or omiting it) works but I'd argue it's less intuitive..

I traced the problem down to calling String.data(using:...) on an empty String which returns nil - Extensions.swift line 38. 

I've added a conditional _if let_ to prevent this and in my testing it seems to have worked. 

I noticed the existing code structure lends very well to so wonder if it was there before but removed for some reason. If you feel this is the wrong way to fix it please feel free to ignore my PR :-)

(I have signed the CLA already)
