### PR TITLE
Fix parsing of QoS bits on Publish packets

### DIFF
--- a/Sources/Publish.swift
+++ b/Sources/Publish.swift
@@ -33,15 +33,15 @@ struct PublishPacket {
         self.qos = qos
         self.topic = topic
         self.message = message
-        
+
     }
 
     init?(header: Byte, bodyLength: Int, data: Data) {
         var data = data
 
         self.controlByte = header
-        self.qos = QosType(rawValue: controlByte & UInt8(0x08))!
-        
+        self.qos = QosType(rawValue: (controlByte & UInt8(0x06)) >> 1)!
+
         topic = data.decodeString
 
         if qos.rawValue > 0 {

--- a/Tests/AphidTests/AphidTests.swift
+++ b/Tests/AphidTests/AphidTests.swift
@@ -105,9 +105,9 @@ class AphidTests: XCTestCase, MQTTDelegate {
         do {
         
         try aphid.connect()
-        
-        aphid.subscribe(topic: [topic], qoss: [.atMostOnce])
-        
+
+        aphid.subscribe(topic: [topic], qoss: [.exactlyOnce])
+
         aphid.publish(topic: topic, withMessage: message, qos: QosType.exactlyOnce)
         } catch {
             expectation.fulfill()
@@ -127,11 +127,11 @@ class AphidTests: XCTestCase, MQTTDelegate {
         testCase = "qos 2"
         receivedCount = 0
         expectation = expectation(description: "Received message exactly Once")
-        
+
         do {
             try aphid.connect()
             
-            aphid.subscribe(topic: [topic], qoss: [.atMostOnce])
+            aphid.subscribe(topic: [topic], qoss: [.exactlyOnce])
             
             aphid.publish(topic: topic, withMessage: message, qos: .exactlyOnce)
         } catch {
@@ -139,7 +139,7 @@ class AphidTests: XCTestCase, MQTTDelegate {
             print("Error: \(error.localizedDescription)")
             XCTFail()
         }
-        
+
         waitForExpectations(timeout: 30) {
             error in
             


### PR DESCRIPTION
Addresses #26. Existing tests are actually mostly sufficient to test this, but because the subscriptions they create are QoS 0, they don't actually test QoS. In other words, if you try the updated tests without the updated code, they should fail.

I think there's another problem with QoS >1 where Aphid won't sent PUBREC or PUBCOMP, but a test gets flaky when I try to fix that, so I haven't included it in this.