### PR TITLE
Add CocoaPods support

### DIFF
--- a/Aphid.podspec
+++ b/Aphid.podspec
@@ -3,14 +3,14 @@ Pod::Spec.new do |s|
   s.version          = "0.5.1"
   s.summary          = "Lightweight MQTT client in Swift 3"
   s.homepage         = "https://github.com/IBM-Swift/Aphid"
-  s.license          = { :type => 'Apache License, Version 2.0' }
+  s.license          = { :type => "Apache License, Version 2.0" }
   s.author           = "IBM"
 
   s.osx.deployment_target = "10.11"
   s.ios.deployment_target = "10.0"
 
   s.source = { :git => "https://github.com/IBM-Swift/Aphid.git", :tag => s.version.to_s }
-  s.source_files = 'Sources/*.swift'
+  s.source_files = "Sources/*.swift"
 
   s.dependency "BlueSocket", "~> 0.12"
   s.dependency "BlueSSLService", "~> 0.12"

--- a/Aphid.podspec
+++ b/Aphid.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source = { :git => "https://github.com/IBM-Swift/Aphid.git", :tag => s.version.to_s }
   s.source_files = 'Sources/*.swift'
 
-  s.dependency 'BlueSocket', '~> 0.12'
-  s.dependency 'BlueSSLService', '~> 0.12'
+  s.dependency "BlueSocket", "~> 0.12"
+  s.dependency "BlueSSLService", "~> 0.12"
   
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => File.read('.swift-version').chomp }
+  s.pod_target_xcconfig = { "SWIFT_VERSION" => "3.1.1" }
 end

--- a/Aphid.podspec
+++ b/Aphid.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name             = "Aphid"
+  s.version          = "0.5.1"
+  s.summary          = "Lightweight MQTT client in Swift 3"
+  s.homepage         = "https://github.com/IBM-Swift/Aphid"
+  s.license          = { :type => 'Apache License, Version 2.0' }
+  s.author           = "IBM"
+
+  s.osx.deployment_target = "10.11"
+  s.ios.deployment_target = "10.0"
+
+  s.source = { :git => "https://github.com/IBM-Swift/Aphid.git", :tag => s.version.to_s }
+  s.source_files = 'Sources/*.swift'
+
+  s.dependency 'BlueSocket', '~> 0.12'
+  s.dependency 'BlueSSLService', '~> 0.12'
+  
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => File.read('.swift-version').chomp }
+end


### PR DESCRIPTION
I've added a Podspec file to allow using Aphid in iOS and macOS projects.
When adding Aphid to your project, also add BlueSocket and BlueSSLService pods:
```
pod "BlueSocket"
pod "BlueSSLService"
pod "Aphid"
```
Or, to use it in another library, add Aphid as a dependency to your Podspec: 
```
s.dependency "Aphid"
```

To use Aphid in your code, import both BlueSocket and Aphid:
```
import Socket
import Aphid
```

I've been able to successfully build Aphid using CocoaPods on both iOS and macOS. 